### PR TITLE
Sync browser theme-color with active theme

### DIFF
--- a/components/ThemeToggle.jsx
+++ b/components/ThemeToggle.jsx
@@ -25,14 +25,17 @@ const ICONS = {
 
 const LABELS = { auto: 'Auto', light: 'Light', dark: 'Dark' };
 
+// Must match --color-bg in styles/globals.css. Used to keep the browser
+// chrome's theme-color in step with the active theme.
+const BG = { light: '#fce2e0', dark: '#2c3e50' };
+
 function applyTheme(theme) {
   const root = document.documentElement;
   const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-  if (theme === 'dark' || (theme === 'auto' && prefersDark)) {
-    root.classList.add('dark');
-  } else {
-    root.classList.remove('dark');
-  }
+  const dark = theme === 'dark' || (theme === 'auto' && prefersDark);
+  root.classList.toggle('dark', dark);
+  const meta = document.querySelector('meta[name="theme-color"]');
+  if (meta) meta.setAttribute('content', dark ? BG.dark : BG.light);
 }
 
 export default function ThemeToggle() {

--- a/lib/sweep.js
+++ b/lib/sweep.js
@@ -37,6 +37,10 @@ export function useCoralSweep() {
       const start = reverse ? '-101%' : '101%';
       const exit = reverse ? '101%' : '-101%';
 
+      // Reveal the panel and promote it to its own layer just for the sweep.
+      el.style.display = 'block';
+      el.style.willChange = 'transform';
+
       // Park at the start edge with no transition, then force a reflow.
       el.style.transition = 'none';
       el.style.transform = `translateY(${start})`;
@@ -57,14 +61,37 @@ export function useCoralSweep() {
       el.style.transform = `translateY(${exit})`;
       await wait(COVER_MS);
 
-      // Reset to the resting (hidden) position.
+      // Reset to rest and fully remove the panel from the render tree, so iOS
+      // Safari stops tinting its chrome bars with the veil's coral. Dropping
+      // the compositor layer (display:none + will-change:auto) forces the
+      // top/bottom bars to re-sample the page background.
       el.style.transition = 'none';
       el.style.transform = 'translateY(101%)';
       el.style.pointerEvents = 'none';
+      el.style.willChange = 'auto';
+      el.style.display = 'none';
       running.current = false;
+
+      // Belt-and-suspenders: re-assert the chrome color once the veil is gone.
+      repaintChrome();
     },
     [router],
   );
+}
+
+// iOS Safari can keep its top/bottom chrome bars tinted with whatever last
+// painted under them until something forces a repaint. Re-inserting the
+// theme-color meta makes Safari re-read it and recolor the bars to the page
+// background. No-op where the meta or DOM is unavailable.
+function repaintChrome() {
+  if (typeof document === 'undefined') return;
+  const meta = document.querySelector('meta[name="theme-color"]');
+  if (!meta || !meta.parentNode) return;
+  const parent = meta.parentNode;
+  const anchor = meta.nextSibling;
+  parent.removeChild(meta);
+  void document.documentElement.offsetWidth; // reflow between remove and insert
+  parent.insertBefore(meta, anchor);
 }
 
 // Shared click handler factory: hijacks a left-click into a sweep, but leaves

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -4,6 +4,10 @@ export default function Document() {
   return (
     <Html lang="en">
       <Head>
+        {/* Pin the browser chrome to the page background so the coral sweep
+            veil never tints iOS Safari's top/bottom bars. ThemeToggle keeps
+            this in sync when the theme changes. Default is the light bg. */}
+        <meta name="theme-color" content="#fce2e0" />
         <link
           href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;900&family=Playfair+Display:ital,wght@0,700;0,800;0,900;1,700;1,800;1,900&display=swap"
           rel="stylesheet"

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -101,15 +101,18 @@ html.dark {
     background: #F98585;
   }
 
-  /* Coral page-transition veil (see components/CoralSweep + lib/sweep) */
+  /* Coral page-transition veil (see components/CoralSweep + lib/sweep).
+     Hidden at rest: a persistent full-viewport fixed layer makes iOS Safari
+     tint its top/bottom chrome bars coral and keep them that way after the
+     sweep. lib/sweep toggles display/will-change only while animating. */
   .coral-sweep-veil {
+    display: none;
     position: fixed;
     inset: 0;
     z-index: 9999;
     background: #F98585;
     transform: translateY(101%);
     pointer-events: none;
-    will-change: transform;
   }
 
   @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
This PR adds support for syncing the browser's theme-color meta tag with the active application theme, ensuring the browser chrome (address bar, status bar, etc.) matches the current light or dark theme.

## Key Changes
- Added `theme-color` meta tag to `_document.js` with a default light background color (`#fce2e0`)
- Created a `BG` constant in `ThemeToggle.jsx` that maps theme modes to their corresponding background colors, matching the values in `styles/globals.css`
- Updated `applyTheme()` function to dynamically update the `theme-color` meta tag when the theme changes
- Refactored theme application logic to use `classList.toggle()` for cleaner code

## Implementation Details
- The `theme-color` meta tag is particularly important for iOS Safari, where it prevents the coral sweep veil from tinting the top and bottom bars
- The `BG` constant must be kept in sync with the `--color-bg` CSS variable in `styles/globals.css`
- The theme color is updated whenever the user changes the theme or when the system preference changes (in auto mode)

https://claude.ai/code/session_01FiaPdSEwRAoodJWeCP1pkZ